### PR TITLE
Feature/1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.2
+
+* Rename the incorrectly named `lib/magic_the_gathering_flutter.dart` to `lib/scryfall_api_symbols.dart` and add exports to it.
+    * Despite being a rename to the main library file, this _should not_ be a breaking change for anyone since the file was not previously exporting any other files. Previously, nobody should have had reason to be importing `lib/magic_the_gathering_flutter.dart` directly.
+* Update `README.md` to tell the user to import the library file directly now that it exports the other files.
+* Update `README.md` with documentation for `mtgSymbology` and `MtgSymbol`.
+* Update the example project to import the library file directly and bump the example's version to 1.0.1
+
 ## 1.0.1
 
 * Add tests for `MtgSymbol` equality

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ dependencies:
   scryfall_api: ^2.1.0
 ```
 
-In any file you have instantiated an [MtgCard](https://pub.dev/documentation/scryfall_api/latest/scryfall_api/MtgCard-class.html) or a [CardFace](https://pub.dev/documentation/scryfall_api/latest/scryfall_api/CardFace-class.html) instance, you can import the following files that contain the extensions:
+In any file you have instantiated an [MtgCard](https://pub.dev/documentation/scryfall_api/latest/scryfall_api/MtgCard-class.html) or a [CardFace](https://pub.dev/documentation/scryfall_api/latest/scryfall_api/CardFace-class.html) instance, you can import the library file to have access to the extension methods:
+
+```dart
+import 'package:scryfall_api_symbols/scryfall_api_symbols.dart';
+```
+
+Or you can import the following files one-by-one if you only need certain functionality:
 
 ```dart
 import 'package:scryfall_api_symbols/extensions/prepared_mana_cost.dart';

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ In any file you have instantiated an [MtgCard](https://pub.dev/documentation/scr
 import 'package:scryfall_api_symbols/scryfall_api_symbols.dart';
 ```
 
-Or you can import the following files one-by-one if you only need certain functionality:
+Importing the library file will also give you access to [mtgSymbology](https://pub.dev/documentation/scryfall_api_symbols/latest/models_mtg_symbology/mtgSymbology-constant.html) and [MtgSymbol](https://pub.dev/documentation/scryfall_api_symbols/latest/models_mtg_symbology/MtgSymbol-class.html).
+
+On the other hand, if you only need certain functionality, you can import the files one-by-one like so:
 
 ```dart
 import 'package:scryfall_api_symbols/extensions/prepared_mana_cost.dart';
 import 'package:scryfall_api_symbols/extensions/prepared_oracle_text.dart';
+import 'package:scryfall_api_symbols/models/mtg_symbology.dart';
 ```
 
 ## API
@@ -72,6 +75,27 @@ import 'package:scryfall_api_symbols/extensions/prepared_oracle_text.dart';
 | :----------------- | :---------------------------------------------------------- | :-------------- |
 | preparedOracleText | Displays the card face's oracle text using MTG symbol SVGs  | `TextSpan?`     |
 
+### MtgSymbol
+
+Represents a single Magic: The Gathering symbol.
+
+#### Methods
+
+| Method             | Description                                                 | Return Type     |
+| :----------------- | :---------------------------------------------------------- | :-------------- |
+| toSvg              | Converts the MtgSymbol object into an SVG widget            | `SvgPicture`    |
+
+#### Properties
+
+| Property           | Description                                                 | Return Type     |
+| :----------------- | :---------------------------------------------------------- | :-------------- |
+| regex              | Matches text that can be converted to an MtgSymbol          | `RegExp`        |
+
+### mtgSymbology
+
+A [Map](https://api.dart.dev/dart-core/Map-class.html) of [String](https://api.dart.dev/dart-core/String-class.html) keys and [MtgSymbol](https://pub.dev/documentation/scryfall_api_symbols/latest/models_mtg_symbology/MtgSymbol-class.html) instance values.
+The keys are based on the notation used in Magic: The Gathering's [Comprehensive Rules](https://magic.wizards.com/en/rules).
+The extension methods use this under the hood.
 
 ## Example
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scryfall_api/scryfall_api.dart' show MtgCard, ScryfallApiClient;
-import 'package:scryfall_api_symbols/extensions/prepared_mana_cost.dart';
-import 'package:scryfall_api_symbols/extensions/prepared_oracle_text.dart';
+import 'package:scryfall_api_symbols/scryfall_api_symbols.dart';
 
 void main() {
   runApp(const MyApp());

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 description: "A Flutter project to demonstrate the use of the scryfall_api_symbols package."
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ^3.6.0

--- a/lib/magic_the_gathering_flutter.dart
+++ b/lib/magic_the_gathering_flutter.dart
@@ -1,1 +1,0 @@
-library;

--- a/lib/scryfall_api_symbols.dart
+++ b/lib/scryfall_api_symbols.dart
@@ -1,0 +1,8 @@
+/// Extensions for the [scryfall_api](https://pub.dev/packages/scryfall_api)
+/// package that simplify displaying Magic: The Gathering symbols as Flutter
+/// widgets.
+library;
+
+export 'extensions/prepared_mana_cost.dart';
+export 'extensions/prepared_oracle_text.dart';
+export 'models/mtg_symbology.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scryfall_api_symbols
 description: Enhance the scryfall_api package with the ability to easily display the MTG symbols as Flutter widgets.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/zmuranaka/scryfall_api_symbols
 issue_tracker: https://github.com/zmuranaka/scryfall_api_symbols/issues
 


### PR DESCRIPTION
* Rename the incorrectly named `lib/magic_the_gathering_flutter.dart` to `lib/scryfall_api_symbols.dart` and add exports to it.
    * Despite being a rename to the main library file, this _should not_ be a breaking change for anyone since the file was not previously exporting any other files. Previously, nobody should have had reason to be importing `lib/magic_the_gathering_flutter.dart` directly.
* Update `README.md` to tell the user to import the library file directly now that it exports the other files.
* Update `README.md` with documentation for `mtgSymbology` and `MtgSymbol`.
* Update the example project to import the library file directly and bump the example's version to 1.0.1