### PR TITLE
Feature/2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3 - March 19, 2026
+
+* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg), [mtg_symbology](https://pub.dev/packages/mtg_symbology), and [scryfall_api](https://pub.dev/packages/scryfall_api) dependency versions
+* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
+* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions
+
 ## 2.0.2 - February 22, 2026
 
 * Upgrade [mtg_symbology](https://pub.dev/packages/mtg_symbology) and [scryfall_api](https://pub.dev/packages/scryfall_api) dependency versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,19 @@ name: scryfall_api_symbols
 description: Enhance the scryfall_api package with the ability to easily display the MTG symbols as Flutter widgets.
 repository: https://github.com/zmuranaka/scryfall_api_symbols
 issue_tracker: https://github.com/zmuranaka/scryfall_api_symbols/issues
-version: 2.0.2
+version: 2.0.3
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  sdk: ^3.9.0
+  flutter: ">=3.35.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_svg: ^2.2.3
-  mtg_symbology: ^1.0.4
-  scryfall_api: ^2.5.2
+  flutter_svg: ^2.2.4
+  mtg_symbology: ^1.0.5
+  scryfall_api: ^2.6.0
 
 dev_dependencies:
-  test: ^1.29.0
-  very_good_analysis: ^10.0.0
+  test: ^1.31.0
+  very_good_analysis: ^10.2.0


### PR DESCRIPTION
* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg), [mtg_symbology](https://pub.dev/packages/mtg_symbology), and [scryfall_api](https://pub.dev/packages/scryfall_api) dependency versions
* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions